### PR TITLE
fix - constant record types

### DIFF
--- a/src/data/airline_record.jsonl
+++ b/src/data/airline_record.jsonl
@@ -1,0 +1,1 @@
+{"airline_id": 1, "record_type": "airline", "company_name": "American Airlines"}

--- a/src/record/airline_record.py
+++ b/src/record/airline_record.py
@@ -15,9 +15,10 @@ class AirlineRecord:
     which is useful for saving to files like JSON.
     """
     def __init__(self,
-                 record_type: str, # Type of record as per requirements
                  company_name: str,
-                 airline_id: Optional[int] = None): # Pylint friendly naming
+                 airline_id: Optional[int] = None,
+                 record_type: str = "airline" # Should consistently be "airline"
+                 ):
         """
         Initializes a new AirlineRecord.
 

--- a/src/record/flight_record.py
+++ b/src/record/flight_record.py
@@ -17,12 +17,12 @@ class FlightRecord:
     suitable for storage and retrieval.
     """
     def __init__(self,
-                 record_type: str,
                  client_id: int,    # Internal attribute name
                  airline_id: int,   # Internal attribute name
                  flight_date: datetime, # Internally a datetime object
                  start_city: str,
                  end_city: str,
+                 record_type: str = "flight" # Should consistently be "flight"
                  # Flight records don't have their own primary ID in the requirements,
                  # they are identified by their association and details.
                  ):


### PR DESCRIPTION
Previously record type fields in airline and flight records was not set as constant unlike client records. This PR ensures that airline and flight records take their respective constant record_type field values of airline and flight.